### PR TITLE
Enabling CI services + increasing coverage by tests

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+fail_on_violations: true
+
+python:
+  enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.5"
+cache: pip
+install:
+  - pip install -r requirements.txt
+script:
+  - python .\api\manage.py test --testrunner 'rooms.custom_test_runner.NoDbTestRunner'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "3.5"
 cache: pip
 install:
-  - pip install -r requirements.txt
+  - pip install -r ./api/requirements.txt
 script:
-  - python .\api\manage.py test --testrunner 'rooms.custom_test_runner.NoDbTestRunner'
+  - python ./api/manage.py test --testrunner 'rooms.custom_test_runner.NoDbTestRunner'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: python
 python:
   - "3.5"
 cache: pip
+services:
+  - postgresql
 install:
   - pip install -r ./api/requirements.txt
   - pip install codecov
 script:
-  -  coverage run --source="./api/." --omit="*migrations*" ./api/manage.py test --testrunner "rooms.custom_test_runner.NoDbTestRunner"
+  - python ./api/manage.py migrate
+  - coverage run --source="./api/." --omit="*migrations*" ./api/manage.py test --testrunner "rooms.custom_test_runner.NoDbTestRunner"
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ python:
 cache: pip
 install:
   - pip install -r ./api/requirements.txt
+  - pip install codecov
 script:
-  - python ./api/manage.py test --testrunner 'rooms.custom_test_runner.NoDbTestRunner'
+  -  coverage run --source="./api/." --omit="*migrations*" ./api/manage.py test --testrunner "rooms.custom_test_runner.NoDbTestRunner"
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Roomie McRoomFace
+# Roomie McRoomFace [![Build Status](https://travis-ci.org/uclapi/roomie_mcroomface.svg?branch=master)](https://travis-ci.org/uclapi/roomie_mcroomface) [![codecov](https://codecov.io/gh/uclapi/roomie_mcroomface/branch/master/graph/badge.svg)](https://codecov.io/gh/uclapi/roomie_mcroomface)
 ## The room booking system for the UCL Engineering Hub
 It's live at [enghub.io](https://enghub.io)
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,14 +8,10 @@ django-celery==3.1.17
 django-cors-headers==1.1.0
 django-dotenv==1.4.1
 djangorestframework==3.4.1
-flake8==3.0.4
 future==0.15.2
 kombu==3.0.35
-mccabe==0.5.2
 opbeat==3.5.1
 psycopg2==2.6.2
-pycodestyle==2.0.0
-pyflakes==1.2.3
 pytz==2016.6.1
 requests==2.11.1
 urllib3==1.16

--- a/api/rooms/custom_permission.py
+++ b/api/rooms/custom_permission.py
@@ -1,6 +1,0 @@
-from rest_framework import permissions
-
-
-class IsOwner(permissions.BasePermission):
-    def has_object_permission(self, request, view, obj):
-        return request.user.user_profile == obj.user

--- a/api/rooms/custom_test_runner.py
+++ b/api/rooms/custom_test_runner.py
@@ -1,0 +1,15 @@
+from django.test.runner import DiscoverRunner
+
+# http://stackoverflow.com/questions/5917587/django-unit-tests-without-a-db
+
+
+class NoDbTestRunner(DiscoverRunner):
+    """ A test runner to test without database creation """
+
+    def setup_databases(self, **kwargs):
+        """ Override the database creation defined in parent class """
+        pass
+
+    def teardown_databases(self, old_config, **kwargs):
+        """ Override the database teardown defined in parent class """
+        pass

--- a/api/rooms/tests.py
+++ b/api/rooms/tests.py
@@ -1,11 +1,13 @@
+import datetime
+
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.test import TestCase
 
 from rooms.models import UserProfile
+from rooms.utils import convertTime, weekOrWeekend
 
 
-# Create your tests here.
 class ResetQuotaTestCase(TestCase):
     def setUp(self):
         self.u1 = User.objects.create(username="aVeryLongRandomTestingString")
@@ -21,3 +23,26 @@ class ResetQuotaTestCase(TestCase):
 
     def tearDown(self):
         self.u1.delete()
+
+
+class UtilsTestCase(TestCase):
+    def test_convert_time(self):
+        for hours in range(0, 24):
+            for minutes in range(0, 60):
+                time_string = "{}:{}".format(hours, minutes)
+                time_object = convertTime(time_string)
+
+                self.assertEqual(time_object.hour, hours)
+                self.assertEqual(time_object.minute, minutes)
+
+    def test_week_or_weekend(self):
+        weekdays = ["26-02-2016", "07-06-2017", "09-10-2018"]
+        weekends = ["04-06-2016", "04-06-2017", "01-04-2018"]
+
+        for weekday in weekdays:
+            dt = datetime.datetime.strptime(weekday, "%d-%m-%Y")
+            self.assertEqual(weekOrWeekend(dt), "week")
+
+        for weekend in weekends:
+            dt = datetime.datetime.strptime(weekend, "%d-%m-%Y")
+            self.assertEqual(weekOrWeekend(dt), "weekend")

--- a/api/rooms/tests.py
+++ b/api/rooms/tests.py
@@ -1,3 +1,23 @@
+from django.contrib.auth.models import User
+from django.core.management import call_command
 from django.test import TestCase
 
+from rooms.models import UserProfile
+
+
 # Create your tests here.
+class ResetQuotaTestCase(TestCase):
+    def setUp(self):
+        self.u1 = User.objects.create(username="aVeryLongRandomTestingString")
+        self.up1 = UserProfile.objects.create(user=self.u1)
+
+    def test_reset_quota(self):
+        self.assertEqual(UserProfile.objects.all()[0].quota_left, 180)
+
+        UserProfile.objects.all()[0].quota_left = 0
+        call_command("reset_quota")
+
+        self.assertEqual(UserProfile.objects.all()[0].quota_left, 180)
+
+    def tearDown(self):
+        self.u1.delete()

--- a/api/rooms/tests.py
+++ b/api/rooms/tests.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from rooms.models import UserProfile
 from rooms.utils import convertTime, weekOrWeekend
+from rooms.views import is_time_valid
 
 
 class ResetQuotaTestCase(TestCase):
@@ -46,3 +47,42 @@ class UtilsTestCase(TestCase):
         for weekend in weekends:
             dt = datetime.datetime.strptime(weekend, "%d-%m-%Y")
             self.assertEqual(weekOrWeekend(dt), "weekend")
+
+
+class IsTimeValidTestCase(TestCase):
+    def setUp(self):
+        self.date = datetime.date(2017, 6, 7)
+        self.start_time = datetime.time(10, 0)
+        self.end_time = datetime.time(15, 0)
+
+    def test_is_time_valid_end_before_start(self):
+        self.end_time = datetime.time(9, 0)
+
+        result = is_time_valid(self.date, self.start_time, self.end_time)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"]["error"], "Invalid times given.")
+
+    def test_is_time_valid_end_after_closing(self):
+        self.end_time = datetime.time(23, 0)
+
+        result = is_time_valid(self.date, self.start_time, self.end_time)
+        self.assertFalse(result["success"])
+        self.assertEqual(
+            result["error"]["error"],
+            "Choose an end time before closing time."
+        )
+
+    def test_is_time_valid_start_before_opening(self):
+        self.start_time = datetime.time(5, 0)
+
+        result = is_time_valid(self.date, self.start_time, self.end_time)
+        self.assertFalse(result["success"])
+        self.assertEqual(
+            result["error"]["error"],
+            "Choose a starting time after opening time."
+        )
+
+    def test_is_time_valid_everything_is_fine(self):
+        result = is_time_valid(self.date, self.start_time, self.end_time)
+        self.assertTrue(result["success"])
+        self.assertIsNone(result.get("error"))

--- a/api/rooms/tests.py
+++ b/api/rooms/tests.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from rooms.models import UserProfile
-from rooms.utils import convertTime, weekOrWeekend
+from rooms.utils import convertTime, random_string, weekOrWeekend
 from rooms.views import is_time_valid
 
 
@@ -27,6 +27,15 @@ class ResetQuotaTestCase(TestCase):
 
 
 class UtilsTestCase(TestCase):
+    def test_random_string(self):
+        s = random_string(0)
+        self.assertFalse(s.isalpha(), False)
+        self.assertEqual(len(s), 0)
+
+        s = random_string(50)
+        self.assertTrue(s.isalpha(), True)
+        self.assertEqual(len(s), 50)
+
     def test_convert_time(self):
         for hours in range(0, 24):
             for minutes in range(0, 60):

--- a/api/rooms/views.py
+++ b/api/rooms/views.py
@@ -313,11 +313,6 @@ def login_callback(request):
     return response
 
 
-@api_view(['GET'])
-def password_changed_successfully(request):
-    return Response({"success": "thanks bud"})
-
-
 # this method is called logout_view so that it does not clash with built-in's
 # logout() method from django.contrib.auth
 @api_view(['GET'])


### PR DESCRIPTION
This PR enables our CI services (TravisCI for building, HoundCI for linting) and adds a custom test runner to run the tests.

Moreover, it increases coverage in our projects by writing tests for the following modules:
* `rooms.management.commands.reset_quota`
* `rooms.utils`
* `rooms.views` (only `is_time_valid` for now)

and by deleting the following dead code:
* `rooms.custom_permission`
* `rooms.utils.views.password_changed_successfully`